### PR TITLE
Fix for Ruby 1.9.3 2014.03 1.0.3 which adds line to edited file

### DIFF
--- a/.ebextensions/ruby.config
+++ b/.ebextensions/ruby.config
@@ -31,7 +31,7 @@ commands:
   symlink_vendor_bundle:
     test: test ! -f /opt/elasticbeanstalk/support/.post-provisioning-complete
     cwd: /opt/elasticbeanstalk/hooks/appdeploy/pre
-    command: sed -i '6iln -s $EB_CONFIG_APP_VENDOR_BUNDLE ./vendor/bundle' 10_bundle_install.sh
+    command: sed -i 's/\(^cd $EB_CONFIG_APP_ONDECK\)/\1\nln -s $EB_CONFIG_APP_VENDOR_BUNDLE .\/vendor\/bundle/' 10_bundle_install.sh
   # Don't run the above commands again on this instance
   #   cf. http://stackoverflow.com/a/16846429/283398
   z_write_post_provisioning_complete_file:


### PR DESCRIPTION
Changing sed command to search for line which inserted item must come after and then insert there using back reference. Original code now inserts on wrong line with Ruby 1.9.3 2014.03 1.0.3 which adds a line to 10_bundle_install.sh making "6" incorrect. This was the safest and backward compatible way to address.
