### PR TITLE
fix update_rubygems missing path

### DIFF
--- a/.ebextensions/ruby.config
+++ b/.ebextensions/ruby.config
@@ -14,7 +14,7 @@ commands:
     leader_only: false
   02_update_rubygems:
     test: test ! -f /opt/elasticbeanstalk/containerfiles/.post-provisioning-complete
-    command: /usr/local/bin/update_rubygems
+    command: $(which update_rubygems)/update_rubygems
     leader_only: false
   # Run rake with bundle exec to be sure you get the right version
   add_bundle_exec:


### PR DESCRIPTION
This change fix the issue caused when the `update_rubygems` path change like in 2016.03 EB image for ruby 2.0 which is at `/opt/rubies/ruby-2.0.0-p648/bin/update_rubygems`
